### PR TITLE
Made EntityManager flush operation Entity specific

### DIFF
--- a/lib/Pike/Session/SaveHandler/Doctrine.php
+++ b/lib/Pike/Session/SaveHandler/Doctrine.php
@@ -161,7 +161,7 @@ class Pike_Session_SaveHandler_Doctrine implements Zend_Session_SaveHandler_Inte
                 $return = $entity->getData();
             } else {
                 self::$em->remove($entity);
-                self::$em->flush();
+                self::$em->flush($this->_entityName);
             }
         }
 
@@ -186,7 +186,7 @@ class Pike_Session_SaveHandler_Doctrine implements Zend_Session_SaveHandler_Inte
         $entity->setModified(new DateTime('now'));
 
         self::$em->persist($entity);
-        self::$em->flush();
+        self::$em->flush($this->_entityName);
 
         return true;
     }
@@ -203,7 +203,7 @@ class Pike_Session_SaveHandler_Doctrine implements Zend_Session_SaveHandler_Inte
 
         if ($entity instanceof Pike_Session_Entity_Interface) {
             self::$em->remove($entity);
-            self::$em->flush();
+            self::$em->flush($this->_entityName);
 
             return true;
         }


### PR DESCRIPTION
I encountered weird behavior where Entities were flushed to the database when I never intended to. It appeared I indicated the session to write and close at the end of PHP execution cycle. Because the EntityManager in the Doctrine Session SaveHandler, performs a general flush, all Entities are flushed, not only the Session Entity.
