### PR TITLE
Fix bug for removing old session on read event

### DIFF
--- a/lib/Pike/Session/SaveHandler/Doctrine.php
+++ b/lib/Pike/Session/SaveHandler/Doctrine.php
@@ -156,8 +156,9 @@ class Pike_Session_SaveHandler_Doctrine implements Zend_Session_SaveHandler_Inte
             } else {
                 $modified = new DateTime($entity->getModified());
             }
-
-            if ($modified->diff(new DateTime('now'))->s < $this->_lifetime) {
+            
+            $duration = (new DateTime('now'))->getTimestamp() - $modified->getTimestamp();
+            if ($duration < $this->_lifetime) {
                 $return = $entity->getData();
             } else {
                 self::$em->remove($entity);


### PR DESCRIPTION
The `DateTime:diff` function gives a `DateInterval` as the result.
The second attribute "s" of an DateInterval is always less than 60. So the condition `$modified->diff(new DateTime('now'))->s < $this->_lifetime` is always true once "lifetime" is greater than 60. And it is the case in most session configurations.
