### PR TITLE
Use lifetime option for the Session

### DIFF
--- a/lib/Pike/Session/SaveHandler/Doctrine.php
+++ b/lib/Pike/Session/SaveHandler/Doctrine.php
@@ -38,7 +38,7 @@
  *
  * 3. Configure Zend_Application_Resource_Session to make it use this save handler and set some other cool options:
  * resources.session.saveHandler.class = "Pike_Session_SaveHandler_Doctrine"
- * resources.session.saveHandler.options.lifetime = 3600
+ * resources.session.remember_me_seconds = 3600
  * resources.session.saveHandler.options.entityName = "Namespace\To\Your\Entity\Session"
  *
  * And you can enjoy Doctrine even more!
@@ -93,7 +93,10 @@ class Pike_Session_SaveHandler_Doctrine implements Zend_Session_SaveHandler_Inte
             }
         }
 
-        $this->_lifetime = Zend_Session::getOptions('gc_maxlifetime');
+        $this->_lifetime = Zend_Session::getOptions('remember_me_seconds');
+        if(empty($this->_lifetime)){
+            $this->_lifetime = Zend_Session::getOptions('gc_maxlifetime');
+        }
     }
 
     /**

--- a/lib/Pike/Session/SaveHandler/Doctrine.php
+++ b/lib/Pike/Session/SaveHandler/Doctrine.php
@@ -38,7 +38,7 @@
  *
  * 3. Configure Zend_Application_Resource_Session to make it use this save handler and set some other cool options:
  * resources.session.saveHandler.class = "Pike_Session_SaveHandler_Doctrine"
- * resources.session.remember_me_seconds = 3600
+ * resources.session.saveHandler.options.lifetime = 3600
  * resources.session.saveHandler.options.entityName = "Namespace\To\Your\Entity\Session"
  *
  * And you can enjoy Doctrine even more!
@@ -90,13 +90,15 @@ class Pike_Session_SaveHandler_Doctrine implements Zend_Session_SaveHandler_Inte
                 case 'entityname' :
                     $this->_entityName = $value;
                     break;
+                case 'lifetime' :
+                    $this->_lifetime = $value;
+                    if(empty($this->_lifetime)){
+                         $this->_lifetime = Zend_Session::getOptions('gc_maxlifetime');
+                    }
+                    break;
             }
         }
 
-        $this->_lifetime = Zend_Session::getOptions('remember_me_seconds');
-        if(empty($this->_lifetime)){
-            $this->_lifetime = Zend_Session::getOptions('gc_maxlifetime');
-        }
     }
 
     /**

--- a/lib/Pike/Session/SaveHandler/Doctrine.php
+++ b/lib/Pike/Session/SaveHandler/Doctrine.php
@@ -92,13 +92,14 @@ class Pike_Session_SaveHandler_Doctrine implements Zend_Session_SaveHandler_Inte
                     break;
                 case 'lifetime' :
                     $this->_lifetime = $value;
-                    if(empty($this->_lifetime)){
-                         $this->_lifetime = Zend_Session::getOptions('gc_maxlifetime');
-                    }
                     break;
             }
         }
-
+        
+        if(empty($this->_lifetime)){
+            $this->_lifetime = Zend_Session::getOptions('gc_maxlifetime');
+        }
+        
     }
 
     /**


### PR DESCRIPTION
Note that the parameter `saveHandler.options.lifetime` seemed to be unused before.
Now the lifetime is set according to this paramete.And if it is unsetted or empty,`gc_maxlifetime` is used.
