### PR TITLE
FIx bug (new Foo)->bar syntax not supported

### DIFF
--- a/lib/Pike/Session/SaveHandler/Doctrine.php
+++ b/lib/Pike/Session/SaveHandler/Doctrine.php
@@ -163,7 +163,7 @@ class Pike_Session_SaveHandler_Doctrine implements Zend_Session_SaveHandler_Inte
                 $modified = new DateTime($entity->getModified());
             }
             
-            $duration = (new DateTime('now'))->getTimestamp() - $modified->getTimestamp();
+            $duration = time() - $modified->getTimestamp();
             if ($duration < $this->_lifetime) {
                 $return = $entity->getData();
             } else {


### PR DESCRIPTION
(new Foo)->bar  is only supported in PHP 5.4 or more
